### PR TITLE
Display wind direction in wind chart's tooltip.

### DIFF
--- a/src/index.html.tmpl
+++ b/src/index.html.tmpl
@@ -267,6 +267,71 @@ new ApexCharts(document.querySelector('#$id'), {
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Get JavaScript code for a chart with extra values in tooltips           |
+## |                                                                         |
+## | string  $name     the name of the database field   (e.g. windSpeed)     |
+## | string  $nameE    the name of the extra field      (e.g. windDir)       |
+## | string  $id       the ID of the chart target       (without hash)       |
+## | string  $type     type of chart                    (area, bar, radar)   |
+## | string  $series1  field name for (1st) series      (e.g. windSpeed)     |
+## | string  $seriesE1 field name for series paired with first (e.g. windDir |
+## | string  $series2  opt. field name for 2nd series   (e.g. windGust or "")|
+## | string  $seriesE2 opt. field name for 4th series   (e.g. windDir or "") |
+## | string  $column   the column of the display value  (e.g. min, max, avg) |
+## +-------------------------------------------------------------------------+
+
+#def getChartJsCodeExtraTooltips($name, $nameE, $id, $type, $series1, $seriesE1, $series2 = "", $seriesE2 = "", $column = "avg")
+
+## Only add JS chart code if in array
+#if $name in $Extras.Appearance.charts_order
+
+new ApexCharts(document.querySelector('#$id'), {
+  ...graph_${type}_config,
+  yaxis: {
+    labels: {
+      formatter: function (val) {
+        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+      }
+    }
+  },
+  tooltip: {
+    y: {
+      formatter: function(value, { series, seriesIndex, dataPointIndex, w }) {
+        return formatNumber(value, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)" + " " + formatNumber(w.config.seriesE[seriesIndex].data[dataPointIndex][1], "$getVar('unit.format.' + nameE)") + "$getVar('unit.label.' + nameE)";
+      }
+    }
+  },
+  series: [
+    {
+      name: "$getVar('obs.label.' + series1)",
+      data: [ $getChartData(series1, column) ]
+    }
+    #if $series2 != "" and $getVar('day.' + series2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + series2)",
+      data: [ $getChartData(series2, column) ]
+    }
+    #end if
+  ],
+  seriesE: [
+    {
+      name: "$getVar('obs.label.' + seriesE1)",
+      data: [ $getChartData(seriesE1, column) ]
+    }
+    #if $seriesE2 != "" and $getVar('day.' + seriesE2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + seriesE2)",
+      data: [ $getChartData(seriesE2, column) ]
+    }
+    #end if
+  ]
+}).render()
+
+#end if
+
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Chart definitions                                                       |
 ## +-------------------------------------------------------------------------+
 
@@ -301,7 +366,7 @@ new ApexCharts(document.querySelector('#$id'), {
   $getChartJsCode("rain", "rainchart", "bar", "rain", "", "sum")
 
   // Wind
-  $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
+  $getChartJsCodeExtraTooltips("windSpeed", "windDir", "windSpeedchart", "area", "windSpeed", "windDir", "windGust", "windGustDir", "max")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/src/month-%Y-%m.html.tmpl
+++ b/src/month-%Y-%m.html.tmpl
@@ -298,6 +298,71 @@ new ApexCharts(document.querySelector('#$id'), {
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Get JavaScript code for a chart with extra values in tooltips           |
+## |                                                                         |
+## | string  $name     the name of the database field   (e.g. windSpeed)     |
+## | string  $nameE    the name of the extra field      (e.g. windDir)       |
+## | string  $id       the ID of the chart target       (without hash)       |
+## | string  $type     type of chart                    (area, bar, radar)   |
+## | string  $series1  field name for (1st) series      (e.g. windSpeed)     |
+## | string  $seriesE1 field name for series paired with first (e.g. windDir |
+## | string  $series2  opt. field name for 2nd series   (e.g. windGust or "")|
+## | string  $seriesE2 opt. field name for 4th series   (e.g. windDir or "") |
+## | string  $column   the column of the display value  (e.g. min, max, avg) |
+## +-------------------------------------------------------------------------+
+
+#def getChartJsCodeExtraTooltips($name, $nameE, $id, $type, $series1, $seriesE1, $series2 = "", $seriesE2 = "", $column = "avg")
+
+## Only add JS chart code if in array
+#if $name in $Extras.Appearance.charts_order
+
+new ApexCharts(document.querySelector('#$id'), {
+  ...graph_${type}_config,
+  yaxis: {
+    labels: {
+      formatter: function (val) {
+        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+      }
+    }
+  },
+  tooltip: {
+    y: {
+      formatter: function(value, { series, seriesIndex, dataPointIndex, w }) {
+        return formatNumber(value, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)" + " " + formatNumber(w.config.seriesE[seriesIndex].data[dataPointIndex][1], "$getVar('unit.format.' + nameE)") + "$getVar('unit.label.' + nameE)";
+      }
+    }
+  },
+  series: [
+    {
+      name: "$getVar('obs.label.' + series1)",
+      data: [ $getChartData(series1, column) ]
+    }
+    #if $series2 != "" and $getVar('day.' + series2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + series2)",
+      data: [ $getChartData(series2, column) ]
+    }
+    #end if
+  ],
+  seriesE: [
+    {
+      name: "$getVar('obs.label.' + seriesE1)",
+      data: [ $getChartData(seriesE1, column) ]
+    }
+    #if $seriesE2 != "" and $getVar('day.' + seriesE2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + seriesE2)",
+      data: [ $getChartData(seriesE2, column) ]
+    }
+    #end if
+  ]
+}).render()
+
+#end if
+
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Chart definitions                                                       |
 ## +-------------------------------------------------------------------------+
 
@@ -332,7 +397,7 @@ new ApexCharts(document.querySelector('#$id'), {
   $getChartJsCode("rain", "rainchart", "bar", "rain", "", "sum")
 
   // Wind
-  $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
+  $getChartJsCodeExtraTooltips("windSpeed", "windDir", "windSpeedchart", "area", "windSpeed", "windDir", "windGust", "windGustDir", "max")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/src/month.html.tmpl
+++ b/src/month.html.tmpl
@@ -249,6 +249,71 @@ new ApexCharts(document.querySelector('#$id'), {
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Get JavaScript code for a chart with extra values in tooltips           |
+## |                                                                         |
+## | string  $name     the name of the database field   (e.g. windSpeed)     |
+## | string  $nameE    the name of the extra field      (e.g. windDir)       |
+## | string  $id       the ID of the chart target       (without hash)       |
+## | string  $type     type of chart                    (area, bar, radar)   |
+## | string  $series1  field name for (1st) series      (e.g. windSpeed)     |
+## | string  $seriesE1 field name for series paired with first (e.g. windDir |
+## | string  $series2  opt. field name for 2nd series   (e.g. windGust or "")|
+## | string  $seriesE2 opt. field name for 4th series   (e.g. windDir or "") |
+## | string  $column   the column of the display value  (e.g. min, max, avg) |
+## +-------------------------------------------------------------------------+
+
+#def getChartJsCodeExtraTooltips($name, $nameE, $id, $type, $series1, $seriesE1, $series2 = "", $seriesE2 = "", $column = "avg")
+
+## Only add JS chart code if in array
+#if $name in $Extras.Appearance.charts_order
+
+new ApexCharts(document.querySelector('#$id'), {
+  ...graph_${type}_config,
+  yaxis: {
+    labels: {
+      formatter: function (val) {
+        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+      }
+    }
+  },
+  tooltip: {
+    y: {
+      formatter: function(value, { series, seriesIndex, dataPointIndex, w }) {
+        return formatNumber(value, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)" + " " + formatNumber(w.config.seriesE[seriesIndex].data[dataPointIndex][1], "$getVar('unit.format.' + nameE)") + "$getVar('unit.label.' + nameE)";
+      }
+    }
+  },
+  series: [
+    {
+      name: "$getVar('obs.label.' + series1)",
+      data: [ $getChartData(series1, column) ]
+    }
+    #if $series2 != "" and $getVar('day.' + series2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + series2)",
+      data: [ $getChartData(series2, column) ]
+    }
+    #end if
+  ],
+  seriesE: [
+    {
+      name: "$getVar('obs.label.' + seriesE1)",
+      data: [ $getChartData(seriesE1, column) ]
+    }
+    #if $seriesE2 != "" and $getVar('day.' + seriesE2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + seriesE2)",
+      data: [ $getChartData(seriesE2, column) ]
+    }
+    #end if
+  ]
+}).render()
+
+#end if
+
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Chart definitions                                                       |
 ## +-------------------------------------------------------------------------+
 
@@ -283,7 +348,7 @@ new ApexCharts(document.querySelector('#$id'), {
   $getChartJsCode("rain", "rainchart", "bar", "rain", "", "sum")
 
   // Wind
-  $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
+  $getChartJsCodeExtraTooltips("windSpeed", "windDir", "windSpeedchart", "area", "windSpeed", "windDir", "windGust", "windGustDir", "max")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/src/week.html.tmpl
+++ b/src/week.html.tmpl
@@ -249,6 +249,71 @@ new ApexCharts(document.querySelector('#$id'), {
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Get JavaScript code for a chart with extra values in tooltips           |
+## |                                                                         |
+## | string  $name     the name of the database field   (e.g. windSpeed)     |
+## | string  $nameE    the name of the extra field      (e.g. windDir)       |
+## | string  $id       the ID of the chart target       (without hash)       |
+## | string  $type     type of chart                    (area, bar, radar)   |
+## | string  $series1  field name for (1st) series      (e.g. windSpeed)     |
+## | string  $seriesE1 field name for series paired with first (e.g. windDir |
+## | string  $series2  opt. field name for 2nd series   (e.g. windGust or "")|
+## | string  $seriesE2 opt. field name for 4th series   (e.g. windDir or "") |
+## | string  $column   the column of the display value  (e.g. min, max, avg) |
+## +-------------------------------------------------------------------------+
+
+#def getChartJsCodeExtraTooltips($name, $nameE, $id, $type, $series1, $seriesE1, $series2 = "", $seriesE2 = "", $column = "avg")
+
+## Only add JS chart code if in array
+#if $name in $Extras.Appearance.charts_order
+
+new ApexCharts(document.querySelector('#$id'), {
+  ...graph_${type}_config,
+  yaxis: {
+    labels: {
+      formatter: function (val) {
+        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+      }
+    }
+  },
+  tooltip: {
+    y: {
+      formatter: function(value, { series, seriesIndex, dataPointIndex, w }) {
+        return formatNumber(value, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)" + " " + formatNumber(w.config.seriesE[seriesIndex].data[dataPointIndex][1], "$getVar('unit.format.' + nameE)") + "$getVar('unit.label.' + nameE)";
+      }
+    }
+  },
+  series: [
+    {
+      name: "$getVar('obs.label.' + series1)",
+      data: [ $getChartData(series1, column) ]
+    }
+    #if $series2 != "" and $getVar('day.' + series2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + series2)",
+      data: [ $getChartData(series2, column) ]
+    }
+    #end if
+  ],
+  seriesE: [
+    {
+      name: "$getVar('obs.label.' + seriesE1)",
+      data: [ $getChartData(seriesE1, column) ]
+    }
+    #if $seriesE2 != "" and $getVar('day.' + seriesE2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + seriesE2)",
+      data: [ $getChartData(seriesE2, column) ]
+    }
+    #end if
+  ]
+}).render()
+
+#end if
+
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Chart definitions                                                       |
 ## +-------------------------------------------------------------------------+
 
@@ -283,7 +348,7 @@ new ApexCharts(document.querySelector('#$id'), {
   $getChartJsCode("rain", "rainchart", "bar", "rain", "", "sum")
 
   // Wind
-  $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
+  $getChartJsCodeExtraTooltips("windSpeed", "windDir", "windSpeedchart", "area", "windSpeed", "windDir", "windGust", "windGustDir", "max")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/src/year-%Y.html.tmpl
+++ b/src/year-%Y.html.tmpl
@@ -342,6 +342,71 @@ new ApexCharts(document.querySelector('#$id'), {
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Get JavaScript code for a chart with extra values in tooltips           |
+## |                                                                         |
+## | string  $name     the name of the database field   (e.g. windSpeed)     |
+## | string  $nameE    the name of the extra field      (e.g. windDir)       |
+## | string  $id       the ID of the chart target       (without hash)       |
+## | string  $type     type of chart                    (area, bar, radar)   |
+## | string  $series1  field name for (1st) series      (e.g. windSpeed)     |
+## | string  $seriesE1 field name for series paired with first (e.g. windDir |
+## | string  $series2  opt. field name for 2nd series   (e.g. windGust or "")|
+## | string  $seriesE2 opt. field name for 4th series   (e.g. windDir or "") |
+## | string  $column   the column of the display value  (e.g. min, max, avg) |
+## +-------------------------------------------------------------------------+
+
+#def getChartJsCodeExtraTooltips($name, $nameE, $id, $type, $series1, $seriesE1, $series2 = "", $seriesE2 = "", $column = "avg")
+
+## Only add JS chart code if in array
+#if $name in $Extras.Appearance.charts_order
+
+new ApexCharts(document.querySelector('#$id'), {
+  ...graph_${type}_config,
+  yaxis: {
+    labels: {
+      formatter: function (val) {
+        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+      }
+    }
+  },
+  tooltip: {
+    y: {
+      formatter: function(value, { series, seriesIndex, dataPointIndex, w }) {
+        return formatNumber(value, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)" + " " + formatNumber(w.config.seriesE[seriesIndex].data[dataPointIndex][1], "$getVar('unit.format.' + nameE)") + "$getVar('unit.label.' + nameE)";
+      }
+    }
+  },
+  series: [
+    {
+      name: "$getVar('obs.label.' + series1)",
+      data: [ $getChartData(series1, column) ]
+    }
+    #if $series2 != "" and $getVar('day.' + series2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + series2)",
+      data: [ $getChartData(series2, column) ]
+    }
+    #end if
+  ],
+  seriesE: [
+    {
+      name: "$getVar('obs.label.' + seriesE1)",
+      data: [ $getChartData(seriesE1, column) ]
+    }
+    #if $seriesE2 != "" and $getVar('day.' + seriesE2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + seriesE2)",
+      data: [ $getChartData(seriesE2, column) ]
+    }
+    #end if
+  ]
+}).render()
+
+#end if
+
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Chart definitions                                                       |
 ## +-------------------------------------------------------------------------+
 
@@ -376,7 +441,7 @@ new ApexCharts(document.querySelector('#$id'), {
   $getChartJsCode("rain", "rainchart", "bar", "rain", "", "sum")
 
   // Wind
-  $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
+  $getChartJsCodeExtraTooltips("windSpeed", "windDir", "windSpeedchart", "area", "windSpeed", "windDir", "windGust", "windGustDir", "max")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/src/year.html.tmpl
+++ b/src/year.html.tmpl
@@ -296,6 +296,71 @@ new ApexCharts(document.querySelector('#$id'), {
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Get JavaScript code for a chart with extra values in tooltips           |
+## |                                                                         |
+## | string  $name     the name of the database field   (e.g. windSpeed)     |
+## | string  $nameE    the name of the extra field      (e.g. windDir)       |
+## | string  $id       the ID of the chart target       (without hash)       |
+## | string  $type     type of chart                    (area, bar, radar)   |
+## | string  $series1  field name for (1st) series      (e.g. windSpeed)     |
+## | string  $seriesE1 field name for series paired with first (e.g. windDir |
+## | string  $series2  opt. field name for 2nd series   (e.g. windGust or "")|
+## | string  $seriesE2 opt. field name for 4th series   (e.g. windDir or "") |
+## | string  $column   the column of the display value  (e.g. min, max, avg) |
+## +-------------------------------------------------------------------------+
+
+#def getChartJsCodeExtraTooltips($name, $nameE, $id, $type, $series1, $seriesE1, $series2 = "", $seriesE2 = "", $column = "avg")
+
+## Only add JS chart code if in array
+#if $name in $Extras.Appearance.charts_order
+
+new ApexCharts(document.querySelector('#$id'), {
+  ...graph_${type}_config,
+  yaxis: {
+    labels: {
+      formatter: function (val) {
+        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+      }
+    }
+  },
+  tooltip: {
+    y: {
+      formatter: function(value, { series, seriesIndex, dataPointIndex, w }) {
+        return formatNumber(value, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)" + " " + formatNumber(w.config.seriesE[seriesIndex].data[dataPointIndex][1], "$getVar('unit.format.' + nameE)") + "$getVar('unit.label.' + nameE)";
+      }
+    }
+  },
+  series: [
+    {
+      name: "$getVar('obs.label.' + series1)",
+      data: [ $getChartData(series1, column) ]
+    }
+    #if $series2 != "" and $getVar('day.' + series2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + series2)",
+      data: [ $getChartData(series2, column) ]
+    }
+    #end if
+  ],
+  seriesE: [
+    {
+      name: "$getVar('obs.label.' + seriesE1)",
+      data: [ $getChartData(seriesE1, column) ]
+    }
+    #if $seriesE2 != "" and $getVar('day.' + seriesE2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + seriesE2)",
+      data: [ $getChartData(seriesE2, column) ]
+    }
+    #end if
+  ]
+}).render()
+
+#end if
+
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Chart definitions                                                       |
 ## +-------------------------------------------------------------------------+
 
@@ -330,7 +395,7 @@ new ApexCharts(document.querySelector('#$id'), {
   $getChartJsCode("rain", "rainchart", "bar", "rain", "", "sum")
 
   // Wind
-  $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
+  $getChartJsCodeExtraTooltips("windSpeed", "windDir", "windSpeedchart", "area", "windSpeed", "windDir", "windGust", "windGustDir", "max")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")

--- a/src/yesterday.html.tmpl
+++ b/src/yesterday.html.tmpl
@@ -268,6 +268,89 @@ new ApexCharts(document.querySelector('#$id'), {
 #end def
 
 ## +-------------------------------------------------------------------------+
+## | Get JavaScript code for a chart with extra values in tooltips           |
+## |                                                                         |
+## | string  $name     the name of the database field   (e.g. windSpeed)     |
+## | string  $nameE    the name of the extra field      (e.g. windDir)       |
+## | string  $id       the ID of the chart target       (without hash)       |
+## | string  $type     type of chart                    (area, bar, radar)   |
+## | string  $series1  field name for (1st) series      (e.g. windSpeed)     |
+## | string  $seriesE1 field name for series paired with first (e.g. windDir |
+## | string  $series2  opt. field name for 2nd series   (e.g. windGust or "")|
+## | string  $seriesE2 opt. field name for 4th series   (e.g. windDir or "") |
+## | string  $column   the column of the display value  (e.g. min, max, avg) |
+## +-------------------------------------------------------------------------+
+
+#def getChartJsCodeExtraTooltips($name, $nameE, $id, $type, $series1, $seriesE1, $series2 = "", $seriesE2 = "", $column = "avg")
+
+## Only add JS chart code if in array
+#if $name in $Extras.Appearance.charts_order
+
+## Get chart data and slice it (only first half of last 48 hours)
+
+series1data = [ $getChartData(series1, column) ];
+half_length1 = Math.ceil(series1data.length / 2);
+
+seriesE1data = [ $getChartData(seriesE1, column) ];
+half_lengthE1 = Math.ceil(seriesE1data.length / 2);
+
+#if $series2 != ""
+series2data = [ $getChartData(series2, column) ];
+half_length2 = Math.ceil(series2data.length / 2);
+#end if
+
+#if $seriesE2 != ""
+seriesE2data = [ $getChartData(seriesE2, column) ];
+half_lengthE2 = Math.ceil(seriesE2data.length / 2);
+#end if
+
+new ApexCharts(document.querySelector('#$id'), {
+  ...graph_${type}_config,
+  yaxis: {
+    labels: {
+      formatter: function (val) {
+        return formatNumber(val, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)";
+      }
+    }
+  },
+  tooltip: {
+    y: {
+      formatter: function(value, { series, seriesIndex, dataPointIndex, w }) {
+        return formatNumber(value, "$getVar('unit.format.' + name)") + "$getVar('unit.label.' + name)" + " " + formatNumber(w.config.seriesE[seriesIndex].data[dataPointIndex][1], "$getVar('unit.format.' + nameE)") + "$getVar('unit.label.' + nameE)";
+      }
+    }
+  },
+  series: [
+    {
+      name: "$getVar('obs.label.' + series1)",
+      data: series1data.splice(0,half_length1)
+    }
+    #if $series2 != "" and $getVar('day.' + series2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + series2)",
+      data: series2data.splice(0,half_length2)
+    }
+    #end if
+  ],
+  seriesE: [
+    {
+      name: "$getVar('obs.label.' + seriesE1)",
+      data: seriesE1data.splice(0,half_lengthE1)
+    }
+    #if $seriesE2 != "" and $getVar('day.' + seriesE2 + '.has_data')
+    ,{
+      name: "$getVar('obs.label.' + seriesE2)",
+      data: seriesE2data.splice(0,half_lengthE2)
+    }
+    #end if
+  ]
+}).render()
+
+#end if
+
+#end def
+
+## +-------------------------------------------------------------------------+
 ## | Chart definitions                                                       |
 ## +-------------------------------------------------------------------------+
 
@@ -306,7 +389,7 @@ new ApexCharts(document.querySelector('#$id'), {
   $getChartJsCode("rain", "rainchart", "bar", "rain", "", "sum")
 
   // Wind
-  $getChartJsCode("windSpeed", "windSpeedchart", "area", "windSpeed", "windGust", "max")
+  $getChartJsCodeExtraTooltips("windSpeed", "windDir", "windSpeedchart", "area", "windSpeed", "windDir", "windGust", "windGustDir", "max")
 
   // outHumidity
   $getChartJsCode("outHumidity", "outHumiditychart", "area", "outHumidity")


### PR DESCRIPTION
Add a new chart type, getChartJsCodeExtraTooltips, which allows to display
extra data in the tooltip. The extra data is stored in a new seriesE
array, and is displayed via the tooltip's y formatter function.

Use it for wind charts.