### PR TITLE
:wrench: Hotfix catalan translation

### DIFF
--- a/src/skin.conf
+++ b/src/skin.conf
@@ -382,9 +382,9 @@
             noaa_export = Informes NOAA
             sun = Sol
             moon = Lluna
-            rise = Sortida del sol
+            rise = Sortida
             transit = Zenit
-            set = Posta del sol
+            set = Posta
             equinox = Equinocci
             solstice = Solstici
             moonphases = Fases de la lluna

--- a/src/skin.conf
+++ b/src/skin.conf
@@ -397,6 +397,9 @@
             winter_solstice = Solstici d'hivern
             mars = Mart
             venus = Vènus
+            saturn = Saturn
+            jupiter = Júpiter
+            telemetry = Telemetria
             hemispheres = N, NE, E, SE, S, SO, O, NO
             
         [[[de]]]

--- a/src/skin.conf
+++ b/src/skin.conf
@@ -362,7 +362,7 @@
             hemispheres = N, NE, E, SE, S, SW, W, NW
 
         [[[ca]]]
-            weather = Oratge
+            weather = Temps
             current = Actual
             yesterday = Ahir
             week = Setmana
@@ -373,7 +373,7 @@
             max = Max
             avg = Mitjana
             min = Min
-            trend = Trend
+            trend = Tendència
             about = Info
             hardware = Maquinari
             altitude = Altitud
@@ -382,9 +382,9 @@
             noaa_export = Informes NOAA
             sun = Sol
             moon = Lluna
-            rise = Eixida
+            rise = Sortida del sol
             transit = Zenit
-            set = Posta
+            set = Posta del sol
             equinox = Equinocci
             solstice = Solstici
             moonphases = Fases de la lluna


### PR DESCRIPTION
:wrench: Fix catalan translations in skin.conf

1. Missing 3 lines in catalan translations causes cheetah.generator errors. Solved by adding translations of words: jupiter, saturn and telemetry
2. Changes in catalan translations of words: weather, trend, rise and set
